### PR TITLE
feat: add version bump script and action

### DIFF
--- a/.github/workflows/trigger_version_bump.yml
+++ b/.github/workflows/trigger_version_bump.yml
@@ -25,11 +25,19 @@ jobs:
           ref: main
           fetch-tags: true
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Git Credentials
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
 
       - name: Update pyproject.toml, commit
         id: update-version
         # TODO: Switch version from 9.9.9 to ${{ inputs.version }}
         # TODO: Remove git checkout zn_versioning
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git checkout zn_versioning
           PR_BRANCH=ci_release_branch_$(date +"%Y%d%m.%H%M%S")
@@ -38,6 +46,8 @@ jobs:
           echo "PR_BRANCH=${PR_BRANCH}" >> ${GITHUB_OUTPUT}
       
       - name: Push and Open Pull Request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # TODO: Switch base from zn_versioning to main
         run: |
           git push --set-upstream origin ${{ steps.update-version.outputs.PR_BRANCH }}

--- a/.github/workflows/trigger_version_bump.yml
+++ b/.github/workflows/trigger_version_bump.yml
@@ -11,9 +11,6 @@ on:
         description: Version to be applied. Must be greater than current version.
         required: true
         type: string
-  push:
-    branches:
-      - zn_versioning #TODO: remove on push trigger
 
 env:
   POETRY_VERSION: 1.8.2
@@ -44,23 +41,19 @@ jobs:
         id: update-version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # TODO: Switch version from 9.9.9 to ${{ inputs.version }}
-        # TODO: Remove git checkout zn_versioning
         run: |
-          git checkout zn_versioning
           PR_BRANCH=ci_release_branch_$(date +"%Y%d%m.%H%M%S")
           git checkout -b ${PR_BRANCH}
-          ci/update-version -v 9.9.9 -c
+          ci/update-version -v ${{ inputs.version }} -c
           echo "PR_BRANCH=${PR_BRANCH}" >> ${GITHUB_OUTPUT}
       
       - name: Push and Open Pull Request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # TODO: Switch base from zn_versioning to main
         run: |
           git push --set-upstream origin ${{ steps.update-version.outputs.PR_BRANCH }}
           gh pr create \
-            --base zn_versioning \
+            --base main \
             --head ${{ steps.update-version.outputs.PR_BRANCH }} \
             --title "$(git log -1 --pretty=%B)" \
             --body "Update version in pyproject.toml to trigger release."

--- a/.github/workflows/trigger_version_bump.yml
+++ b/.github/workflows/trigger_version_bump.yml
@@ -1,0 +1,41 @@
+name: Trigger Version Bump
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to be applied. Must be greater than current version.
+        required: true
+        type: string
+
+jobs:
+  update_version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-tags: true
+          fetch-depth: 0
+
+      - name: Update pyproject.toml, commit
+        id: update-version
+        run: |
+          PR_BRANCH=ci_release_branch_$(date +"%Y%d%m.%H%M%S")
+          git checkout -b ${PR_BRANCH}
+          ci/update-version -v ${{ inputs.version }} -c
+          echo "PR_BRANCH=${PR_BRANCH}" >> ${GITHUB_OUTPUT}
+      
+      - name: Push and Open Pull Request
+        run: |
+          git push --set-upstream origin ${{ steps.update-version.outputs.PR_BRANCH }}
+          gh pr create \
+            --base main \
+            --head ${{ steps.update-version.outputs.PR_BRANCH }} \
+            --title "$(git log -1 --pretty=%B)" \
+            --body "Update version in pyproject.toml to trigger release."

--- a/.github/workflows/trigger_version_bump.yml
+++ b/.github/workflows/trigger_version_bump.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Update pyproject.toml, commit
         id: update-version
         # TODO: Switch version from 9.9.9 to ${{ inputs.version }}
+        # TODO: Remove git checkout zn_versioning
         run: |
+          git checkout zn_versioning
           PR_BRANCH=ci_release_branch_$(date +"%Y%d%m.%H%M%S")
           git checkout -b ${PR_BRANCH}
           ci/update-version -v 9.9.9 -c

--- a/.github/workflows/trigger_version_bump.yml
+++ b/.github/workflows/trigger_version_bump.yml
@@ -11,9 +11,6 @@ on:
         description: Version to be applied. Must be greater than current version.
         required: true
         type: string
-  push:
-    branches:
-      - zn_versioning # TODO: Remove on push trigger
 
 jobs:
   update_version:
@@ -34,25 +31,21 @@ jobs:
 
       - name: Update pyproject.toml, commit
         id: update-version
-        # TODO: Switch version from 9.9.9 to ${{ inputs.version }}
-        # TODO: Remove git checkout zn_versioning
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git checkout zn_versioning
           PR_BRANCH=ci_release_branch_$(date +"%Y%d%m.%H%M%S")
           git checkout -b ${PR_BRANCH}
-          ci/update-version -v 9.9.9 -c
+          ci/update-version -v ${{ inputs.version }} -c
           echo "PR_BRANCH=${PR_BRANCH}" >> ${GITHUB_OUTPUT}
       
       - name: Push and Open Pull Request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # TODO: Switch base from zn_versioning to main
         run: |
           git push --set-upstream origin ${{ steps.update-version.outputs.PR_BRANCH }}
           gh pr create \
-            --base zn_versioning \
+            --base main \
             --head ${{ steps.update-version.outputs.PR_BRANCH }} \
             --title "$(git log -1 --pretty=%B)" \
             --body "Update version in pyproject.toml to trigger release."

--- a/.github/workflows/trigger_version_bump.yml
+++ b/.github/workflows/trigger_version_bump.yml
@@ -11,6 +11,9 @@ on:
         description: Version to be applied. Must be greater than current version.
         required: true
         type: string
+  push:
+    branches:
+      - zn_versioning # TODO: Remove on push trigger
 
 jobs:
   update_version:
@@ -25,17 +28,19 @@ jobs:
 
       - name: Update pyproject.toml, commit
         id: update-version
+        # TODO: Switch version from 9.9.9 to ${{ inputs.version }}
         run: |
           PR_BRANCH=ci_release_branch_$(date +"%Y%d%m.%H%M%S")
           git checkout -b ${PR_BRANCH}
-          ci/update-version -v ${{ inputs.version }} -c
+          ci/update-version -v 9.9.9 -c
           echo "PR_BRANCH=${PR_BRANCH}" >> ${GITHUB_OUTPUT}
       
       - name: Push and Open Pull Request
+        # TODO: Switch base from zn_versioning to main
         run: |
           git push --set-upstream origin ${{ steps.update-version.outputs.PR_BRANCH }}
           gh pr create \
-            --base main \
+            --base zn_versioning \
             --head ${{ steps.update-version.outputs.PR_BRANCH }} \
             --title "$(git log -1 --pretty=%B)" \
             --body "Update version in pyproject.toml to trigger release."

--- a/.github/workflows/trigger_version_bump.yml
+++ b/.github/workflows/trigger_version_bump.yml
@@ -11,6 +11,12 @@ on:
         description: Version to be applied. Must be greater than current version.
         required: true
         type: string
+  push:
+    branches:
+      - zn_versioning #TODO: remove on push trigger
+
+env:
+  POETRY_VERSION: 1.8.2
 
 jobs:
   update_version:
@@ -29,23 +35,32 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
+      - name: Install poetry
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry==${{env.POETRY_VERSION}}
+
       - name: Update pyproject.toml, commit
         id: update-version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # TODO: Switch version from 9.9.9 to ${{ inputs.version }}
+        # TODO: Remove git checkout zn_versioning
         run: |
+          git checkout zn_versioning
           PR_BRANCH=ci_release_branch_$(date +"%Y%d%m.%H%M%S")
           git checkout -b ${PR_BRANCH}
-          ci/update-version -v ${{ inputs.version }} -c
+          ci/update-version -v 9.9.9 -c
           echo "PR_BRANCH=${PR_BRANCH}" >> ${GITHUB_OUTPUT}
       
       - name: Push and Open Pull Request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # TODO: Switch base from zn_versioning to main
         run: |
           git push --set-upstream origin ${{ steps.update-version.outputs.PR_BRANCH }}
           gh pr create \
-            --base main \
+            --base zn_versioning \
             --head ${{ steps.update-version.outputs.PR_BRANCH }} \
             --title "$(git log -1 --pretty=%B)" \
             --body "Update version in pyproject.toml to trigger release."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,11 @@ To generate a code coverage report locally, run the following command:
 ```console
 poetry run coverage html
 ```
+
+# Building the Docker Image
+
+The docker image can be built by running:
+
+```console
+ci/docker-build-image
+```

--- a/ci/docker-build-image
+++ b/ci/docker-build-image
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() { cat << EOF
+Usage: $0 [-hn]
+
+Build Docker image from this local repository.
+
+The image will be tagged with the version of this repository by setting the
+environmental variable LONGPLEXPY_VERSION using a Git-aware command.
+
+Any unstaged changes within this local repository will be included in the Docker
+image. Unstaged changes will dirty the version string for the Docker image with
+a '-dirty' suffix.
+
+Ensure your Docker daemon is running with these minimum resource allocations:
+
+    CPUs:               8
+    Memory:             8 Gb
+    Swap:               1 Gb
+    Disk Image Size:    60 Gb (default, less may also work)
+
+Options:
+    -h  Display this information.
+    -n  Do not use the Docker cache during build. (Optional)
+EOF
+}
+
+DOCKER_NO_CACHE="";
+while getopts "hn" OPTION; do
+    case "$OPTION" in
+        h) usage; exit 1;;
+        n) DOCKER_NO_CACHE="--no-cache";;
+        [?]) usage; (>&2 echo "Exception: Unknown options ${*}."); exit 1;;
+    esac
+done
+
+SOURCE_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+LONGPLEXPY_VERSION="$(git describe --exact-match 2>/dev/null || git describe --abbrev=7 --tags --dirty)"
+
+pushd "${SOURCE_DIR}"/..
+
+docker build \
+    ${DOCKER_NO_CACHE} \
+    --tag seqwell/longplexpy:"${LONGPLEXPY_VERSION}" \
+    --file docker/Dockerfile \
+    .
+
+popd

--- a/ci/docker-build-image
+++ b/ci/docker-build-image
@@ -39,12 +39,11 @@ SOURCE_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 
 LONGPLEXPY_VERSION="$(git describe --exact-match 2>/dev/null || git describe --abbrev=7 --tags --dirty)"
 
-pushd "${SOURCE_DIR}"/..
-
-docker build \
-    ${DOCKER_NO_CACHE} \
-    --tag seqwell/longplexpy:"${LONGPLEXPY_VERSION}" \
-    --file docker/Dockerfile \
-    .
-
-popd
+(
+    cd "${SOURCE_DIR}"/.. && \
+    docker build \
+        ${DOCKER_NO_CACHE} \
+        --tag seqwell/longplexpy:"${LONGPLEXPY_VERSION}" \
+        --file docker/Dockerfile \
+        .
+)

--- a/ci/update-version
+++ b/ci/update-version
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() { cat << EOF
+Usage: $0 [-hcv]
+
+Update version stored in pyproject.toml file. Optionally, commit change.
+New version must be greater than the previous version.
+
+Options:
+    -h  Display this information.
+    -c  Specify the change should be committed. (Optional)
+    -v  A specific version to be used in updating nextflow.config and to apply as a tag if requested.
+EOF
+}
+
+COMMIT=""; VERSION=""
+while getopts "hcv:" OPTION; do
+    case "$OPTION" in
+        h) usage; exit 1;;
+        c) COMMIT=true;;
+        v) VERSION=${OPTARG};;
+        \?) usage; (>&2 echo "Exception: Unknown option $OPTION."); exit 1;;
+    esac
+done
+
+if [ -z "${VERSION}" ];
+then
+    usage; (>&2 echo "Exception: No version supplied."); exit 1
+fi
+
+if [ -z "$(git tag --merged main --sort=taggerdate)" ];
+then
+    echo "No previous version found, proceeding with ${VERSION}"
+else
+    PREVIOUS_VERSION=$(git tag --merged main --sort=taggerdate | grep "^[0-9\.]\+$" | tail -n 1)
+    if ! printf "%s\n%s\n" "${PREVIOUS_VERSION}" "${VERSION}" | sort -V -C; then
+        echo "ERROR ${VERSION} is less than the previous version, ${PREVIOUS_VERSION}." 1>&2
+        exit 1
+    fi
+fi
+
+echo "Updating pyproject.toml to version: ${VERSION}"
+
+case "$OSTYPE" in
+    darwin*|bsd*)
+        echo "Using BSD sed style"
+        sed_no_backup=( -i '' )
+        ;;
+    *)
+        echo "Using GNU sed style"
+        sed_no_backup=( -i )
+        ;;
+esac
+
+sed -E "${sed_no_backup[@]}" "s/^(version[[:space:]]+=[[:space:]])\"(.*)\"/\1\"${VERSION}\"/" pyproject.toml
+
+if [ -n "${COMMIT}" ];
+then
+    echo "Generating a new commit!"
+    git add pyproject.toml
+    git commit -m "chore(${VERSION}): update pyproject version"
+fi

--- a/ci/update-version
+++ b/ci/update-version
@@ -6,6 +6,7 @@ Usage: $0 [-hcv]
 
 Update version stored in pyproject.toml file. Optionally, commit change.
 New version must be greater than the previous version.
+Requires poetry be installed.
 
 Options:
     -h  Display this information.
@@ -40,20 +41,7 @@ else
     fi
 fi
 
-echo "Updating pyproject.toml to version: ${VERSION}"
-
-case "$OSTYPE" in
-    darwin*|bsd*)
-        echo "Using BSD sed style"
-        sed_no_backup=( -i '' )
-        ;;
-    *)
-        echo "Using GNU sed style"
-        sed_no_backup=( -i )
-        ;;
-esac
-
-sed -E "${sed_no_backup[@]}" "s/^(version[[:space:]]+=[[:space:]])\"(.*)\"/\1\"${VERSION}\"/" pyproject.toml
+poetry version "${VERSION}"
 
 if [ -n "${COMMIT}" ];
 then

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:bookworm-20240513-slim AS base
+
+ENV LANG=C.UTF-8
+
+RUN apt-get update \
+    && apt upgrade --yes \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        python3.11-dev \
+        python3.11-full \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Poetry
+RUN curl -sSL https://install.python-poetry.org | python3 - --yes
+
+ENV PATH="/root/.local/bin:$PATH"
+
+ENV POETRY_VIRTUALENVS_CREATE=false
+
+ARG POETRY_VERSION=1.8.4
+
+RUN poetry self update ${POETRY_VERSION}
+
+# Install longplexpy
+ENV PATH="/opt/venv-longplexpy/bin:$PATH"
+
+RUN python3 -m venv /opt/venv-longplexpy
+
+COPY ./ /longplexpy
+
+RUN . /opt/venv-longplexpy/bin/activate \
+    && cd longplexpy \
+    && poetry build \
+    && pip install dist/*.whl
+
+RUN ln -s /opt/venv-longplexpy/bin/longplexpy /bin/longplexpy


### PR DESCRIPTION
This PR adds a `ci/update-version` script which can be used to update the version stored in `pyproject.toml`.

It also adds a github action triggered by a workflow dispatch (GUI) that will:
1. Checkout this repository
2. Compare the new version to the previous version to ensure it's higher
3. Checkout a new branch
4. Update the pyproject.toml script
5. Commit the change and push up to github
6. Open a pull request with the change

One thing to note is that we're using the github action token for these steps, so the initial commit and pull request will not trigger other automations. When a user merges the pull request, that merge commit will trigger other automations.

See this action trigger: https://github.com/seqwell/longplexpy/actions/runs/11746405567
From this PR: https://github.com/seqwell/longplexpy/pull/7

Remaining automation steps:
1. Add an action that will tag the commit with the `chore(#.#.#)` commit message
2. Add an action that will generate a release when a tag is added to main matching the versioning pattern
3. Add an action that will build and push the docker image to dockerhub on any merge to main (versioning of the image is handled in the `docker-build-image` script).