### PR TITLE
feat: add tag and release action

### DIFF
--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -14,8 +14,8 @@ jobs:
   release_commit_check:
     runs-on: ubuntu-latest
     outputs:
-        release_commit_check: ${{ steps.check_version_bump.release_commit_check }}
-        new_version: ${{ steps.check_version_bump.new_version }}
+        release_commit_check: ${{ steps.check_version_bump.outputs.release_commit_check }}
+        new_version: ${{ steps.check_version_bump.outputs.new_version }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -37,53 +37,53 @@ jobs:
   add_version:
     runs-on: ubuntu-latest
     needs: release_commit_check
-    # if: ${{ needs.release_commit_check.outputs.release_commit_check == 'true' }}
+    if: ${{ needs.release_commit_check.outputs.release_commit_check == 'true' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Add Version Tag
-      #   uses: rickstaa/action-create-tag@v1
-      #   with:
-      #     tag: ${{ needs.release_commit_check.outputs.new_version }}
-      #     commit_sha: ${{ github.sha }}
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add Version Tag
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: ${{ needs.release_commit_check.outputs.new_version }}
+          commit_sha: ${{ github.sha }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
   
-  # draft_changelog:
-  #   runs-on: ubuntu-latest
-  #   needs: [add_version, release_commit_check]
-  #   outputs:
-  #     release_body: ${{ steps.git_cliff.outputs.content }}
-  #   steps:
-  #     - name: Checkout Repository at Tagged Commit
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
-  #         ref: ${{ needs.release_commit_check.outputs.new_version }}
-  #     - name: Generate Changelog
-  #       id: git_cliff
-  #       uses: orhun/git-cliff-action@v4
-  #       with:
-  #         args: --latest --verbose
-  #       env:
-  #         GITHUB_REPO: ${{ github.repository }}
+  draft_changelog:
+    runs-on: ubuntu-latest
+    needs: [add_version, release_commit_check]
+    outputs:
+      release_body: ${{ steps.git_cliff.outputs.content }}
+    steps:
+      - name: Checkout Repository at Tagged Commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.release_commit_check.outputs.new_version }}
+      - name: Generate Changelog
+        id: git_cliff
+        uses: orhun/git-cliff-action@v4
+        with:
+          args: --latest --verbose
+        env:
+          GITHUB_REPO: ${{ github.repository }}
   
-  # create_github_release:
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: write
-  #     pull-requests: read
-  #   needs: [release_commit_check, draft_changelog]
-  #   steps:
-  #     - name: Create Release
-  #       uses: softprops/action-gh-release@v2
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         name: ${{ needs.release_commit_check.outputs.new_version }}
-  #         body: |
-  #           ${{ needs.draft_changelog.outputs.release_body }}
-  #         draft: true # TODO: Switch to False
-  #         prerelease: false
+  create_github_release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    needs: [release_commit_check, draft_changelog]
+    steps:
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: ${{ needs.release_commit_check.outputs.new_version }}
+          body: |
+            ${{ needs.draft_changelog.outputs.release_body }}
+          draft: true # TODO: Switch to False
+          prerelease: false
 

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -37,53 +37,53 @@ jobs:
   add_version:
     runs-on: ubuntu-latest
     needs: release_commit_check
-    if: ${{ needs.release_commit_check.outputs.release_commit_check == 'true' }}
+    # if: ${{ needs.release_commit_check.outputs.release_commit_check == 'true' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Add Version Tag
-        uses: rickstaa/action-create-tag@v1
-        with:
-          tag: ${{ needs.release_commit_check.outputs.new_version }}
-          commit_sha: ${{ github.sha }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Add Version Tag
+      #   uses: rickstaa/action-create-tag@v1
+      #   with:
+      #     tag: ${{ needs.release_commit_check.outputs.new_version }}
+      #     commit_sha: ${{ github.sha }}
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
   
-  draft_changelog:
-    runs-on: ubuntu-latest
-    needs: [add_version, release_commit_check]
-    outputs:
-      release_body: ${{ steps.git_cliff.outputs.content }}
-    steps:
-      - name: Checkout Repository at Tagged Commit
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.release_commit_check.outputs.new_version }}
-      - name: Generate Changelog
-        id: git_cliff
-        uses: orhun/git-cliff-action@v4
-        with:
-          args: --latest --verbose
-        env:
-          GITHUB_REPO: ${{ github.repository }}
+  # draft_changelog:
+  #   runs-on: ubuntu-latest
+  #   needs: [add_version, release_commit_check]
+  #   outputs:
+  #     release_body: ${{ steps.git_cliff.outputs.content }}
+  #   steps:
+  #     - name: Checkout Repository at Tagged Commit
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #         ref: ${{ needs.release_commit_check.outputs.new_version }}
+  #     - name: Generate Changelog
+  #       id: git_cliff
+  #       uses: orhun/git-cliff-action@v4
+  #       with:
+  #         args: --latest --verbose
+  #       env:
+  #         GITHUB_REPO: ${{ github.repository }}
   
-  create_github_release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: read
-    needs: [release_commit_check, draft_changelog]
-    steps:
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          name: ${{ needs.release_commit_check.outputs.new_version }}
-          body: |
-            ${{ needs.draft_changelog.outputs.release_body }}
-          draft: true # TODO: Switch to False
-          prerelease: false
+  # create_github_release:
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: write
+  #     pull-requests: read
+  #   needs: [release_commit_check, draft_changelog]
+  #   steps:
+  #     - name: Create Release
+  #       uses: softprops/action-gh-release@v2
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         name: ${{ needs.release_commit_check.outputs.new_version }}
+  #         body: |
+  #           ${{ needs.draft_changelog.outputs.release_body }}
+  #         draft: true # TODO: Switch to False
+  #         prerelease: false
 

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -8,7 +8,7 @@ permissions:
 on:
   push:
     branches:
-      - zn_release
+      - main
 
 jobs:
   release_commit_check:
@@ -84,6 +84,5 @@ jobs:
           name: ${{ needs.release_commit_check.outputs.new_version }}
           body: |
             ${{ needs.draft_changelog.outputs.release_body }}
-          draft: true # TODO: Switch to False
+          draft: false
           prerelease: false
-

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -25,11 +25,11 @@ jobs:
         id: check_version_bump
         run: |
           MESSAGE="${{ github.event.head_commit.message }}"
-          BUMP_REGEX="^chore\([0-9]\.[0-9]\.[0-9]\): update pipeline version.*"
+          BUMP_REGEX="^chore\([0-9]\.[0-9]\.[0-9]\): update pyproject version.*"
           BUMP_MATCH=$(echo ${MESSAGE} | egrep "${BUMP_REGEX}") || true # Prevent error code on no match
           if [ -n "${BUMP_MATCH}" ]
           then
-            NEW_VERSION=$(echo $BUMP_MATCH | sed -E "s/chore\(|\): update pipeline version.*//g")
+            NEW_VERSION=$(echo $BUMP_MATCH | sed -E "s/chore\(|\): update pyproject version.*//g")
             echo "release_commit_check=true" >> $GITHUB_OUTPUT
             echo "new_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           fi
@@ -84,6 +84,6 @@ jobs:
           name: ${{ needs.release_commit_check.outputs.new_version }}
           body: |
             ${{ needs.draft_changelog.outputs.release_body }}
-          draft: true #TODO: Switch to False
+          draft: true # TODO: Switch to False
           prerelease: false
 

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -1,0 +1,89 @@
+
+name: Add Version Tag
+
+permissions:
+  id-token: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release_commit_check:
+    runs-on: ubuntu-latest
+    outputs:
+        release_commit_check: ${{ steps.check_version_bump.release_commit_check }}
+        new_version: ${{ steps.check_version_bump.new_version }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check For Version Bump
+        id: check_version_bump
+        run: |
+          MESSAGE="${{ github.event.head_commit.message }}"
+          BUMP_REGEX="^chore\([0-9]\.[0-9]\.[0-9]\): update pipeline version.*"
+          BUMP_MATCH=$(echo ${MESSAGE} | egrep "${BUMP_REGEX}") || true # Prevent error code on no match
+          if [ -n "${BUMP_MATCH}" ]
+          then
+            NEW_VERSION=$(echo $BUMP_MATCH | sed -E "s/chore\(|\): update pipeline version.*//g")
+            echo "release_commit_check=true" >> $GITHUB_OUTPUT
+            echo "new_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          fi
+
+  add_version:
+    runs-on: ubuntu-latest
+    needs: release_commit_check
+    if: ${{ needs.release_commit_check.outputs.release_commit_check == 'true' }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add Version Tag
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: ${{ needs.release_commit_check.outputs.new_version }}
+          commit_sha: ${{ github.sha }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+  
+  draft_changelog:
+    runs-on: ubuntu-latest
+    needs: [add_version, release_commit_check]
+    outputs:
+      release_body: ${{ steps.git_cliff.outputs.content }}
+    steps:
+      - name: Checkout Repository at Tagged Commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.release_commit_check.outputs.new_version }}
+      - name: Generate Changelog
+        id: git_cliff
+        uses: orhun/git-cliff-action@v4
+        with:
+          args: --latest --verbose
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+  
+  create_github_release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    needs: [release_commit_check, draft_changelog]
+    steps:
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: ${{ needs.release_commit_check.outputs.new_version }}
+          body: |
+            ${{ needs.draft_changelog.outputs.release_body }}
+          draft: true #TODO: Switch to False
+          prerelease: false
+

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -8,7 +8,7 @@ permissions:
 on:
   push:
     branches:
-      - main
+      - zn_release
 
 jobs:
   release_commit_check:


### PR DESCRIPTION
This new github action will trigger after merging the PR opened by the "Trigger Version Bump" action.

This new action will:
- Trigger on commits to main
- Check the commit message matches the "chore(#.#.#): update pyproject version" pattern
- Add a tag to the commit as the specified version, #.#.#
- Draft a changelog using git-cliff
- Publish a new release for the tag with the changelog autopopulated

You can see a full run of the action here: https://github.com/seqwell/longplexpy/actions/runs/12164477385
And an example of the release drafted:
<img width="1170" alt="image" src="https://github.com/user-attachments/assets/9c2b107f-33cb-446a-a81f-1f1a696cebcd">
