### PR TITLE
Fix parsing of counts file by skipping second row

### DIFF
--- a/longplexpy/multiqc_plugin/modules/lima_longplex/__init__.py
+++ b/longplexpy/multiqc_plugin/modules/lima_longplex/__init__.py
@@ -87,7 +87,11 @@ class LimaCountMetric:
     @classmethod
     def from_counts_text(cls, lima_counts_text: str) -> "LimaCountMetric":
         well_counts: dict = {}
-        for row in csv.reader(lima_counts_text.splitlines(), delimiter="\t"):
+        lines = lima_counts_text.splitlines()
+        # Skip the second row (index 1) if it exists
+        if len(lines) > 1:
+            lines = [lines[0]] + lines[2:]
+        for row in csv.reader(lines, delimiter="\t"):
             if len(row) == 0 or "Counts" in row:
                 continue
             else:


### PR DESCRIPTION
Fixes an issue where the counts file parser fails when the second row doesn't contain the expected seqwell_UDI1 format.

**Problem:**
The parser was trying to process all rows, but the second row may not have the expected format, causing parsing errors.

**Solution:**
- Modified `LimaCountMetric.from_counts_text()` to skip the second row before processing
- Added logic to remove line at index 1 while preserving header and data rows

**Testing:**
- Tested with counts files that have the problematic second row format
- Confirmed the parser now works correctly